### PR TITLE
Bump versions and remove options for pandoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "jekyll", "3.2.1"
 gem "minima"
 
 # pandoc
-gem "jekyll-pandoc"
+gem "jekyll-pandoc", "2.0.1"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     colorator (1.1.0)
-    ffi (1.9.14)
+    ffi (1.9.23)
     forwardable-extended (2.6.0)
     jekyll (3.2.1)
       colorator (~> 1.0)
@@ -17,33 +17,39 @@ GEM
     jekyll-pandoc (2.0.1)
       jekyll (>= 3.0)
       pandoc-ruby (~> 2.0, >= 2.0.0)
-    jekyll-sass-converter (1.4.0)
+    jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
-    jekyll-watch (1.5.0)
-      listen (~> 3.0, < 3.1)
-    kramdown (1.12.0)
+    jekyll-watch (1.5.1)
+      listen (~> 3.0)
+    kramdown (1.16.2)
     liquid (3.0.6)
-    listen (3.0.8)
+    listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     mercenary (0.3.6)
     minima (1.0.1)
-    pandoc-ruby (2.0.1)
-    pathutil (0.14.0)
+    pandoc-ruby (2.0.2)
+    pathutil (0.16.1)
       forwardable-extended (~> 2.6)
-    rb-fsevent (0.9.7)
-    rb-inotify (0.9.7)
-      ffi (>= 0.5.0)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rouge (1.11.1)
+    ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.4.22)
+    sass (3.5.6)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   jekyll (= 3.2.1)
-  jekyll-pandoc
+  jekyll-pandoc (= 2.0.1)
   minima
 
 RUBY VERSION

--- a/_config.yml
+++ b/_config.yml
@@ -17,8 +17,8 @@ markdown: Pandoc
 
 pandoc:
   extensions:
-    - normalize
-    - smart
+    # - normalize
+    # - smart
     - mathjax
     # - csl: _styles/apa.csl
     # - bibliography: bibliography/references.bib


### PR DESCRIPTION
Pandoc remove some options such as `--normalize` and `--smart`. 